### PR TITLE
Fix converter regression

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/primitive/PrimitiveConverter.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/primitive/PrimitiveConverter.kt
@@ -6,6 +6,7 @@ import com.papsign.ktor.openapigen.parameters.parsers.converters.ConverterSelect
 import com.papsign.ktor.openapigen.parameters.util.localDateTimeFormatter
 import com.papsign.ktor.openapigen.parameters.util.offsetDateTimeFormatter
 import com.papsign.ktor.openapigen.parameters.util.zonedDateTimeFormatter
+import io.ktor.util.reflect.*
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.*
@@ -14,6 +15,7 @@ import java.time.format.DateTimeParseException
 import java.util.*
 import kotlin.reflect.KType
 
+@Suppress("RemoveExplicitTypeArguments")
 object PrimitiveConverter : ConverterSelector {
 
     private inline fun <reified T> primitive(noinline cvt: (String) -> T): Pair<KType, Converter> {
@@ -35,14 +37,14 @@ object PrimitiveConverter : ConverterSelector {
             it.toLongOrNull() ?: 0
         },
         primitive { it.toLongOrNull() },
-        primitive {
+        primitive<BigInteger> {
             it.toBigIntegerOrNull() ?: BigInteger.ZERO
         },
-        primitive { it.toBigIntegerOrNull() },
-        primitive {
+        primitive<BigInteger?> { it.toBigIntegerOrNull() },
+        primitive<BigDecimal> {
             it.toBigDecimalOrNull() ?: BigDecimal.ZERO
         },
-        primitive { it.toBigDecimalOrNull() },
+        primitive<BigDecimal?> { it.toBigDecimalOrNull() },
         primitive { it.toFloatOrNull() ?: 0f },
         primitive { it.toFloatOrNull() },
         primitive {
@@ -53,90 +55,86 @@ object PrimitiveConverter : ConverterSelector {
         primitive<Boolean?> { it.toBoolean() },
         // removed temporarily because behavior may not be standard or expected
 
-        primitive {
+        primitive<LocalDate> {
             LocalDate.parse(it, DateTimeFormatter.ISO_DATE)
         },
-        primitive {
+        primitive<LocalDate?> {
             try {
                 LocalDate.parse(it, DateTimeFormatter.ISO_DATE)
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-        primitive {
+        primitive<LocalTime> {
             LocalTime.parse(it, DateTimeFormatter.ISO_LOCAL_TIME)
         },
-        primitive {
+        primitive<LocalTime?> {
             try {
                 LocalTime.parse(it, DateTimeFormatter.ISO_LOCAL_TIME)
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-        primitive {
+        primitive<OffsetTime> {
             OffsetTime.parse(it, DateTimeFormatter.ISO_OFFSET_TIME)
         },
-        primitive {
+        primitive<OffsetTime?> {
             try {
                 OffsetTime.parse(it, DateTimeFormatter.ISO_OFFSET_TIME)
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-        primitive {
+        primitive<LocalDateTime> {
             LocalDateTime.parse(it, localDateTimeFormatter)
         },
-        primitive {
+        primitive<LocalDateTime?> {
             try {
                 LocalDateTime.parse(it, localDateTimeFormatter)
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-        primitive {
+        primitive<OffsetDateTime> {
             OffsetDateTime.parse(it, offsetDateTimeFormatter)
         },
-        primitive {
+        primitive<OffsetDateTime?> {
             try {
                 OffsetDateTime.parse(it, offsetDateTimeFormatter)
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-        primitive {
+        primitive<ZonedDateTime> {
             ZonedDateTime.parse(it, zonedDateTimeFormatter)
         },
-        primitive {
+        primitive<ZonedDateTime?> {
             try {
                 ZonedDateTime.parse(it, zonedDateTimeFormatter)
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-        primitive { it.toLongOrNull()?.let(Instant::ofEpochMilli) ?: Instant.from(offsetDateTimeFormatter.parse(it)) },
-        primitive {
+        primitive<Instant> {
+            it.toLongOrNull()?.let(Instant::ofEpochMilli) ?: Instant.from(offsetDateTimeFormatter.parse(it))
+        },
+        primitive<Instant?> {
             try {
                 it.toLongOrNull()?.let(Instant::ofEpochMilli) ?: Instant.from(offsetDateTimeFormatter.parse(it))
-            } catch(e: DateTimeParseException) {
+            } catch (e: DateTimeParseException) {
                 null
             }
         },
 
-//        primitive { it?.toLongOrNull()?.let(::Date) ?: it?.let(dateFormat::parse) ?: Date() },
-//        primitive { it?.toLongOrNull()?.let(::Date) ?: it?.let(dateFormat::parse) },
 
-        primitive {
-            try {
-                UUID.fromString(it)
-            } catch (e: IllegalArgumentException) {
-                null
-            } ?: UUID(0, 0)
+        primitive<UUID> {
+            UUID.fromString(it)
         },
         primitive {
             try {

--- a/src/test/kotlin/GeneralBehaviorTest.kt
+++ b/src/test/kotlin/GeneralBehaviorTest.kt
@@ -1,5 +1,5 @@
 import com.papsign.ktor.openapigen.getKType
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.*
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubtypeOf

--- a/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
+++ b/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
@@ -5,7 +5,7 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 
 internal class JwtAuthDocumentationGenerationTest {

--- a/src/test/kotlin/OneOf.kt
+++ b/src/test/kotlin/OneOf.kt
@@ -16,7 +16,7 @@ import com.papsign.ktor.openapigen.route.route
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 fun NormalOpenAPIRoute.SealedRoute() {
     route("sealed") {

--- a/src/test/kotlin/com/papsign/ktor/openapigen/FormDocumentationGenerationTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/FormDocumentationGenerationTest.kt
@@ -13,7 +13,7 @@ import io.ktor.server.application.log
 import io.ktor.server.testing.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 internal class FormDocumentationGenerationTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParserTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParserTest.kt
@@ -11,7 +11,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.InputStream
 import kotlin.random.Random
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParserTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParserTest.kt
@@ -66,7 +66,7 @@ class BinaryContentTypeParserTest {
                 addHeader(HttpHeaders.Accept, contentType)
                 setBody(bytes)
             }.apply {
-                assertEquals(HttpStatusCode.NotFound, response.status())
+                assertEquals(HttpStatusCode.UnsupportedMediaType, response.status())
             }
 
             println("Test: Bad Accept")
@@ -75,7 +75,7 @@ class BinaryContentTypeParserTest {
                 addHeader(HttpHeaders.Accept, ContentType.Application.Json.toString())
                 setBody(bytes)
             }.apply {
-                assertEquals(HttpStatusCode.NotFound, response.status())
+                assertEquals(HttpStatusCode.BadRequest, response.status())
             }
 
             println("Test: Bad Content-Type")
@@ -84,7 +84,7 @@ class BinaryContentTypeParserTest {
                 addHeader(HttpHeaders.Accept, contentType)
                 setBody(bytes)
             }.apply {
-                assertEquals(HttpStatusCode.NotFound, response.status())
+                assertEquals(HttpStatusCode.UnsupportedMediaType, response.status())
             }
         }
     }

--- a/src/test/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProviderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProviderTest.kt
@@ -12,7 +12,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/ArrayBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/ArrayBuilderTest.kt
@@ -2,7 +2,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ArrayBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/CustomBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/CustomBuilderTest.kt
@@ -7,8 +7,8 @@ import com.papsign.ktor.openapigen.parameters.parsers.converters.primitive.Primi
 import com.papsign.ktor.openapigen.parameters.parsers.converters.primitive.PrimitiveConverterFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import com.papsign.ktor.openapigen.parameters.parsers.testSelectorFails
-import org.junit.After
-import org.junit.Before
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -16,12 +16,12 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 
 class InjectBeforeTest {
-    @Before
+    @BeforeEach
     fun before() {
         PrimitiveConverterFactory.injectConverterBefore(PrimitiveConverter::class, CustomUuidConverter)
     }
 
-    @After
+    @AfterEach
     fun after() {
         PrimitiveConverterFactory.removeConverter(CustomUuidConverter::class)
     }
@@ -40,13 +40,13 @@ class InjectBeforeTest {
 }
 
 class InjectAfterAndRemoveTest {
-    @Before
+    @BeforeEach
     fun before() {
         PrimitiveConverterFactory.injectConverterAfter(PrimitiveConverter::class, AnyToBooleanConverter)
         PrimitiveConverterFactory.removeConverter(PrimitiveConverter::class)
     }
 
-    @After
+    @AfterEach
     fun after() {
         PrimitiveConverterFactory.injectConverterBefore(AnyToBooleanConverter::class, PrimitiveConverter)
         PrimitiveConverterFactory.removeConverter(AnyToBooleanConverter::class)

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/CustomBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/CustomBuilderTest.kt
@@ -30,7 +30,7 @@ class InjectBeforeTest {
     fun testCustomConverter() {
         val uuid = "4a5e1ba7-c6fe-49de-abf9-d94614ea3bb8"
         val key = "key"
-        val expected = UUID.fromString(uuid)
+        val expected: UUID = UUID.fromString(uuid)
         val parse = mapOf(
             key to listOf(uuid)
         )

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/CustomBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/CustomBuilderTest.kt
@@ -9,7 +9,7 @@ import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import com.papsign.ktor.openapigen.parameters.parsers.testSelectorFails
 import org.junit.After
 import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.reflect.KType

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/EnumBuilderTest.kt
@@ -5,7 +5,7 @@ import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
 import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/ListBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/ListBuilderTest.kt
@@ -2,7 +2,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ListBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/MapBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/MapBuilderTest.kt
@@ -2,7 +2,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MapBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/ObjectBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/ObjectBuilderTest.kt
@@ -2,7 +2,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ObjectBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/OptionalBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/OptionalBuilderTest.kt
@@ -2,7 +2,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.*
 
 class OptionalBuilderTest {

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/PrimitiveBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/PrimitiveBuilderTest.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import com.papsign.ktor.openapigen.parameters.parsers.testSelectorFails
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.*
 
 class PrimitiveBuilderTest {

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/PrimitiveBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/PrimitiveBuilderTest.kt
@@ -21,7 +21,7 @@ class PrimitiveBuilderTest {
     @Test
     fun testLocalDate() {
         val key = "key"
-        val expected = LocalDate.of(2021, Month.FEBRUARY, 27)
+        val expected: LocalDate = LocalDate.of(2021, Month.FEBRUARY, 27)
         val parse = mapOf(
             key to listOf("2021-02-27")
         )
@@ -33,7 +33,7 @@ class PrimitiveBuilderTest {
     fun testLocalTime() {
         val key = "key"
 
-        val cases = listOf(
+        val cases = listOf<Pair<String, LocalTime>>(
             "10:30:00" to LocalTime.of(10, 30, 0),
             "10:30" to LocalTime.of(10, 30, 0),
             "10:30:00.1" to LocalTime.of(10, 30, 0, 100_000_000),
@@ -62,7 +62,7 @@ class PrimitiveBuilderTest {
     fun testOffsetTime() {
         val key = "key"
 
-        val cases = listOf(
+        val cases = listOf<Pair<String, OffsetTime>>(
             "10:30:00+03:00" to OffsetTime.of(LocalTime.of(10, 30, 0), ZoneOffset.ofHours(3)),
             "10:30+03:00" to OffsetTime.of(LocalTime.of(10, 30, 0), ZoneOffset.ofHours(3)),
             "10:30Z" to OffsetTime.of(LocalTime.of(10, 30, 0), ZoneOffset.UTC),
@@ -96,7 +96,7 @@ class PrimitiveBuilderTest {
 
         val baseDate = LocalDate.of(2021, Month.FEBRUARY, 27)
 
-        val cases = listOf(
+        val cases = listOf<Pair<String, LocalDateTime>>(
             "2021-02-27T10:30:00" to LocalDateTime.of(baseDate, LocalTime.of(10, 30, 0)),
             "2021-02-27 10:30:00" to LocalDateTime.of(baseDate, LocalTime.of(10, 30, 0)),
             "2021-02-27 10:30" to LocalDateTime.of(baseDate, LocalTime.of(10, 30, 0)),
@@ -133,7 +133,7 @@ class PrimitiveBuilderTest {
 
         val baseDateTime = LocalDateTime.of(LocalDate.of(2021, Month.FEBRUARY, 27), LocalTime.of(10, 30, 0))
 
-        val cases = listOf(
+        val cases = listOf<Pair<String, OffsetDateTime>>(
             "2021-02-27T10:30:00+03:00" to OffsetDateTime.of(baseDateTime, ZoneOffset.ofHours(3)),
             "2021-02-27 10:30:00+03:00" to OffsetDateTime.of(baseDateTime, ZoneOffset.ofHours(3)),
             "2021-02-27 10:30:00+03" to OffsetDateTime.of(baseDateTime, ZoneOffset.ofHours(3)),
@@ -181,7 +181,7 @@ class PrimitiveBuilderTest {
 
         val baseDateTime = LocalDateTime.of(LocalDate.of(2021, Month.FEBRUARY, 27), LocalTime.of(10, 30, 0))
 
-        val cases = listOf(
+        val cases = listOf<Pair<String, ZonedDateTime>>(
             "2021-02-27T10:30:00+03:00" to ZonedDateTime.of(baseDateTime, ZoneOffset.ofHours(3)),
             "2021-02-27T10:30:00+03:00[Europe/Moscow]" to ZonedDateTime.of(baseDateTime, ZoneId.of("Europe/Moscow")),
             "2021-02-27T10:30:00+03[Europe/Moscow]" to ZonedDateTime.of(baseDateTime, ZoneId.of("Europe/Moscow")),
@@ -235,7 +235,7 @@ class PrimitiveBuilderTest {
         val instant = OffsetDateTime.of(LocalDate.of(2021, Month.FEBRUARY, 27), LocalTime.of(10, 30, 0), ZoneOffset.UTC).toInstant()
         val epochMillis = instant.toEpochMilli()
 
-        val cases = listOf(
+        val cases = listOf<Pair<String, Instant>>(
             "2021-02-27T10:30:00Z" to instant,
             "2021-02-27 10:30:00Z" to instant,
             "2021-02-27 10:30:00+00:00" to instant,

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/ArrayBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/ArrayBuilderTest.kt
@@ -1,7 +1,7 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ArrayBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/EnumBuilderTest.kt
@@ -4,7 +4,7 @@ import com.papsign.ktor.openapigen.annotations.type.enum.StrictEnumParsing
 import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
 import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/ListBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/ListBuilderTest.kt
@@ -1,7 +1,7 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ListBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/MapBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/MapBuilderTest.kt
@@ -1,7 +1,7 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MapBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/ObjectBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/ObjectBuilderTest.kt
@@ -1,7 +1,7 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ObjectBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/OptionalBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/OptionalBuilderTest.kt
@@ -1,7 +1,7 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.*
 
 class OptionalBuilderTest {

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/PrimitiveBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/PrimitiveBuilderTest.kt
@@ -1,7 +1,7 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PrimitiveBuilderTest {
 

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericRoutesTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericRoutesTest.kt
@@ -26,7 +26,7 @@ import io.ktor.server.auth.basic
 import io.ktor.server.response.respond
 import io.ktor.server.testing.*
 import io.ktor.util.pipeline.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericsTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericsTest.kt
@@ -15,7 +15,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 
 class GenericsTest {

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/RoutingTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/RoutingTest.kt
@@ -16,7 +16,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 
 class RoutingTest {


### PR DESCRIPTION
After updating to Kotlin 1.6, KTypes like OffsetDateTime are now to resolved as a platform type of OffsetDateTime! and the type mapping was broken.

Also fixed tests that didn't run because they weren't ported to JUnit 5.
