### PR TITLE
Fix regex enforcement false negative bug

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/pattern/RegularExpressionConstraintProcessor.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/pattern/RegularExpressionConstraintProcessor.kt
@@ -24,7 +24,7 @@ abstract class RegularExpressionConstraintProcessor<A: Annotation>(): SchemaProc
     private class RegularExpressionConstraintValidator(private val constraint: RegularExpressionConstraint): Validator {
         override fun <T> validate(subject: T?): T? {
             if (subject is String?) {
-                if (subject == null || !constraint.pattern.toRegex().containsMatchIn(subject)) {
+                if (subject == null || !constraint.pattern.toRegex().matches(subject)) {
                     throw RegularExpressionConstraintViolation(subject, constraint)
                 }
             } else {

--- a/src/test/kotlin/RegexExample.kt
+++ b/src/test/kotlin/RegexExample.kt
@@ -1,0 +1,41 @@
+import com.papsign.ktor.openapigen.OpenAPIGen
+import com.papsign.ktor.openapigen.annotations.type.string.pattern.RegularExpression
+import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.post
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+
+/**
+ * Example of using regex validator.
+ */
+fun Application.regexExample() {
+    // install OpenAPI plugin
+    install(OpenAPIGen) {
+        // this servers OpenAPI definition on /openapi.json
+        serveOpenApiJson = true
+        // this servers Swagger UI on /swagger-ui/index.html
+        serveSwaggerUi = true
+        info {
+            title = "Minimal Example API"
+        }
+    }
+    // install JSON support
+    install(ContentNegotiation) {
+        jackson()
+    }
+    // and now example routing
+    apiRouting {
+        route("/example") {
+            post<Unit, RegexExampleResponse, RegexExampleRequest> {_, _ ->
+                respond(RegexExampleResponse("ok"))
+            }
+        }
+    }
+}
+
+data class RegexExampleRequest(@RegularExpression("[0-9]{4}") val fourDigits: String)
+data class RegexExampleResponse(val ok: String)

--- a/src/test/kotlin/RegexExampleTest.kt
+++ b/src/test/kotlin/RegexExampleTest.kt
@@ -1,0 +1,42 @@
+import com.papsign.ktor.openapigen.annotations.type.string.pattern.RegularExpressionConstraintViolation
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.jackson.jackson
+import org.junit.jupiter.api.assertThrows
+
+class RegexExampleTest {
+    @Test
+    fun `test that regex validator works`(): Unit = testApplication {
+//        application(testApplication {  })
+        application(Application::regexExample)
+        val client = createClient { install(ContentNegotiation) { jackson() } }
+
+        assertThrows<RegularExpressionConstraintViolation> {
+            client.post("/example") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(RegexExampleRequest(fourDigits = "1"))
+            }
+        }
+
+        assertThrows<RegularExpressionConstraintViolation> {
+            client.post("/example") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(RegexExampleRequest(fourDigits = "12345"))
+            }
+        }
+
+        assertEquals(HttpStatusCode.OK, client.post("/example") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody(RegexExampleRequest(fourDigits = "1234"))
+        }.status)
+    }
+}


### PR DESCRIPTION
For `@RegularExpression` enforcement, the existing use of `containsMatchIn` is problematic in that it allows unwanted strings. 

For example, with `Request(@RegularExpression("[0-9]{4}") val fourDigits: String)`,  unwanted string "12345" can pass the validation unexpectedly.

This PR also contains a test for the described issue too. I'm not sure if there's a better way and better place to test this enforcement within the exiting test files, so feel free to let me know if any exiting file can host this test case better!